### PR TITLE
Move legend to description, add 'nearby_images'-block

### DIFF
--- a/mcsurfacegr.json
+++ b/mcsurfacegr.json
@@ -4,7 +4,7 @@
         "nl":   "Ondergrond GR paden"
         },
     "icon": "https://www.groteroutepaden.be/style/theme/images/favicons/main/android-icon-192x192.png",
-    "description": "MapComplete thema om snel en eenvoudig de ondergrond van GR paden aan OSM toe te voegen.",
+    "description": "MapComplete thema om snel en eenvoudig de ondergrond van GR paden aan OSM toe te voegen.<p><span style=\"color: #0000ff;\">&#9608;&#9608;&#9608;</span> Onverhard&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style=\"color: #0083e2;\">&#9608;&#9608;&#9608;</span> Halfverharde&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style=\"color: #8ecdfa;\">&#9608;&#9608;&#9608;</span> Verhard</p><p><span style=\"color: #ff2d00;\">&#9608;&#9608;&#9608;</span> <b>Onbekende ondergrond</b></p>",
     "language": [
         "nl"
     ],
@@ -119,7 +119,7 @@
             "mappings": [],
             "tagRenderings": [
                 {
-                    "render": "<p><span style=\"color: #0000ff;\">&#9608;&#9608;&#9608;</span> Onverhard&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style=\"color: #0083e2;\">&#9608;&#9608;&#9608;</span> Halfverharde&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span style=\"color: #8ecdfa;\">&#9608;&#9608;&#9608;</span> Verhard</p><p><span style=\"color: #ff2d00;\">&#9608;&#9608;&#9608;</span> <b>Onbekende ondergrond</b></p>"
+                    "render": "{nearby_images()}"
                 },
                 {
                     "id": "way-surface",


### PR DESCRIPTION
I felt the 'legend' was more at home in the introductory text (as it is not specific to a selected road)

I added the 'nearby images'-block instead

![image](https://user-images.githubusercontent.com/1466478/190411665-cfb73cac-04ae-478c-8520-5c5456b34857.png)

Did you know that you can reuse questions from existing layers? You could thus use a single string `cycleways_and_roads.Surface of the road` (*) to reuse that question. Improvements there would automatically be reflected in your custom theme.

(*) this is actually a horrible id, with the spaces...